### PR TITLE
Revamp Hugo PaperMod blog to match branding

### DIFF
--- a/blog/assets/css/extended/custom.css
+++ b/blog/assets/css/extended/custom.css
@@ -1,0 +1,924 @@
+:root {
+  --dm-primary: #1e40af;
+  --dm-primary-light: #3b82f6;
+  --dm-primary-dark: #1e3a8a;
+  --dm-secondary: #f59e0b;
+  --dm-accent: #10b981;
+  --dm-surface: #ffffff;
+  --dm-surface-alt: #f8fafc;
+  --dm-surface-soft: rgba(30, 64, 175, 0.06);
+  --dm-text: #0f172a;
+  --dm-text-muted: #64748b;
+  --dm-border: #e2e8f0;
+  --dm-radius: 0.75rem;
+  --dm-radius-lg: 1.25rem;
+  --dm-shadow-sm: 0 12px 35px -20px rgba(15, 23, 42, 0.45);
+  --dm-shadow: 0 25px 55px -30px rgba(30, 64, 175, 0.45);
+  --dm-shadow-lg: 0 35px 80px -40px rgba(15, 23, 42, 0.45);
+  --dm-font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', system-ui, sans-serif;
+  --dm-font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+  --dm-transition: 220ms cubic-bezier(0.4, 0, 0.2, 1);
+  --dm-hero-gradient: linear-gradient(135deg, rgba(30, 64, 175, 0.12) 0%, rgba(16, 185, 129, 0.12) 100%);
+  --main-width: 1100px;
+  --gap: 1.75rem;
+  --header-height: 84px;
+}
+
+body {
+  font-family: var(--dm-font-sans);
+  background: var(--dm-surface);
+  color: var(--dm-text);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body.dark {
+  --dm-surface: #0f172a;
+  --dm-surface-alt: #111827;
+  --dm-surface-soft: rgba(59, 130, 246, 0.12);
+  --dm-text: #f8fafc;
+  --dm-text-muted: #94a3b8;
+  --dm-border: #334155;
+  --dm-shadow-sm: 0 12px 35px -20px rgba(2, 6, 23, 0.75);
+  --dm-shadow: 0 25px 55px -30px rgba(15, 23, 42, 0.9);
+  --dm-shadow-lg: 0 35px 90px -40px rgba(15, 23, 42, 0.85);
+}
+
+a {
+  color: var(--dm-primary);
+  transition: color var(--dm-transition);
+}
+
+a:hover {
+  color: var(--dm-primary-light);
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  inset-inline: 0;
+  z-index: 1200;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(18px) saturate(160%);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
+  border-bottom: 1px solid var(--dm-border);
+  transition: box-shadow var(--dm-transition), transform var(--dm-transition), background var(--dm-transition);
+}
+
+body.dark .header {
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.header.is-scrolled {
+  box-shadow: var(--dm-shadow-sm);
+  transform: translateY(-2px);
+}
+
+.nav {
+  max-width: var(--main-width);
+  margin: 0 auto;
+  padding: 1rem clamp(1.25rem, 4vw, 2.5rem);
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 2vw, 2.5rem);
+}
+
+.logo > a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  color: var(--dm-text);
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+  transition: transform var(--dm-transition), color var(--dm-transition);
+}
+
+.logo > a:hover {
+  transform: translateX(4px);
+  color: var(--dm-primary);
+}
+
+.logo-switches {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: clamp(1rem, 4vw, 2.5rem);
+}
+
+#menu {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 4vw, 2rem);
+  margin-left: auto;
+  list-style: none;
+}
+
+#menu li {
+  list-style: none;
+}
+
+#menu a {
+  position: relative;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--dm-text-muted);
+  padding: 0.35rem 0;
+  transition: color var(--dm-transition);
+}
+
+#menu a span {
+  position: relative;
+  padding-bottom: 0.1rem;
+}
+
+#menu a span::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.25rem;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(135deg, var(--dm-primary), var(--dm-primary-light));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--dm-transition);
+}
+
+#menu a:hover,
+#menu a span.active {
+  color: var(--dm-primary);
+}
+
+#menu a:hover span::after,
+#menu a span.active::after {
+  transform: scaleX(1);
+}
+
+#theme-toggle {
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  border: 2px solid var(--dm-border);
+  background: var(--dm-surface-alt);
+  display: grid;
+  place-items: center;
+  color: var(--dm-text);
+  transition: transform var(--dm-transition), border-color var(--dm-transition), background var(--dm-transition), color var(--dm-transition);
+}
+
+#theme-toggle:hover {
+  transform: scale(1.07);
+  border-color: var(--dm-primary);
+  background: var(--dm-surface);
+  color: var(--dm-primary);
+}
+
+main.main {
+  max-width: none;
+  padding: 0;
+  background: var(--dm-surface);
+}
+
+main.main > * {
+  width: 100%;
+}
+
+.home {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 6vw, 5rem);
+}
+
+.home .section-wrapper {
+  width: min(var(--main-width), calc(100% - clamp(2rem, 6vw, 5rem)));
+  margin: 0 auto;
+}
+
+.home-hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(6rem, 12vw, 8rem) 0 clamp(4rem, 9vw, 6.5rem);
+}
+
+.home-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--dm-hero-gradient);
+  opacity: 0.7;
+}
+
+.home-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle at 20% 20%, rgba(30, 64, 175, 0.15) 0, transparent 55%),
+    radial-gradient(circle at 75% 75%, rgba(16, 185, 129, 0.12) 0, transparent 50%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.home-hero .section-wrapper {
+  position: relative;
+  z-index: 1;
+}
+
+.home-hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(2.5rem, 6vw, 3.5rem);
+  align-items: center;
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(148, 163, 184, 0.15));
+  color: var(--dm-accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero-badge::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--dm-accent);
+  box-shadow: 0 0 0 6px rgba(16, 185, 129, 0.22);
+  animation: heroPulse 2.8s ease-in-out infinite;
+}
+
+.hero-title {
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.025em;
+  color: var(--dm-text);
+}
+
+.hero-title strong {
+  color: var(--dm-primary);
+}
+
+.hero-subtitle {
+  font-size: clamp(1.05rem, 2.2vw, 1.25rem);
+  color: var(--dm-text-muted);
+  max-width: 42ch;
+}
+
+.hero-companies {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.hero-companies span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(30, 64, 175, 0.18);
+  color: var(--dm-text-muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  transition: transform var(--dm-transition), box-shadow var(--dm-transition), color var(--dm-transition), background var(--dm-transition);
+}
+
+body.dark .hero-companies span {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.hero-companies span:hover {
+  transform: translateY(-2px);
+  color: var(--dm-primary);
+  box-shadow: var(--dm-shadow-sm);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: var(--dm-radius);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  min-height: 46px;
+  transition: transform var(--dm-transition), box-shadow var(--dm-transition), color var(--dm-transition), background var(--dm-transition);
+}
+
+.hero-actions a.primary {
+  color: #fff;
+  background: linear-gradient(135deg, var(--dm-primary), var(--dm-primary-light));
+  box-shadow: var(--dm-shadow-sm);
+}
+
+.hero-actions a.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--dm-shadow);
+}
+
+.hero-actions a.secondary {
+  color: var(--dm-primary);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(30, 64, 175, 0.25);
+}
+
+body.dark .hero-actions a.secondary {
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--dm-text);
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.hero-actions a.secondary:hover {
+  transform: translateY(-1px);
+  color: var(--dm-primary);
+}
+
+.hero-image-wrapper {
+  position: relative;
+  justify-self: center;
+}
+
+.hero-image-wrapper::before {
+  content: "";
+  position: absolute;
+  inset: -1.5rem;
+  border-radius: var(--dm-radius-lg);
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.25), rgba(59, 130, 246, 0.15));
+  filter: blur(40px);
+  opacity: 0.8;
+  z-index: 0;
+}
+
+.hero-image {
+  position: relative;
+  z-index: 1;
+  width: min(320px, 70vw);
+  border-radius: var(--dm-radius-lg);
+  box-shadow: var(--dm-shadow-lg);
+  border: 3px solid rgba(255, 255, 255, 0.8);
+}
+
+body.dark .hero-image {
+  border-color: rgba(15, 23, 42, 0.8);
+}
+
+.section-header {
+  margin-bottom: clamp(1.75rem, 4vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.section-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(30, 64, 175, 0.1);
+  color: var(--dm-primary);
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-title {
+  font-size: clamp(1.85rem, 3.6vw, 2.45rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--dm-text);
+}
+
+.section-description {
+  font-size: clamp(1rem, 2.1vw, 1.15rem);
+  color: var(--dm-text-muted);
+  max-width: 60ch;
+}
+
+.about-body {
+  background: var(--dm-surface-alt);
+  border: 1px solid var(--dm-border);
+  border-radius: var(--dm-radius-lg);
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  box-shadow: var(--dm-shadow-sm);
+  color: var(--dm-text-muted);
+}
+
+.about-body p {
+  margin-bottom: 1rem;
+}
+
+.focus-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.focus-card {
+  background: var(--dm-surface-alt);
+  border: 1px solid var(--dm-border);
+  border-radius: var(--dm-radius-lg);
+  padding: clamp(1.5rem, 4vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform var(--dm-transition), box-shadow var(--dm-transition), border-color var(--dm-transition);
+}
+
+.focus-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--dm-shadow-sm);
+  border-color: rgba(30, 64, 175, 0.35);
+}
+
+.focus-card h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--dm-primary-dark);
+}
+
+.focus-card p {
+  color: var(--dm-text-muted);
+}
+
+.focus-card ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.focus-card li {
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(30, 64, 175, 0.2);
+  font-size: 0.8rem;
+  color: var(--dm-primary);
+  background: rgba(30, 64, 175, 0.06);
+}
+
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.post-card {
+  background: var(--dm-surface);
+  border: 1px solid var(--dm-border);
+  border-radius: var(--dm-radius-lg);
+  padding: clamp(1.5rem, 4vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--dm-shadow-sm);
+  transition: transform var(--dm-transition), box-shadow var(--dm-transition), border-color var(--dm-transition);
+}
+
+body.dark .post-card {
+  background: var(--dm-surface-alt);
+}
+
+.post-card:hover {
+  transform: translateY(-6px) scale(1.01);
+  box-shadow: var(--dm-shadow);
+  border-color: rgba(30, 64, 175, 0.35);
+}
+
+.post-card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--dm-text);
+}
+
+.post-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--dm-text-muted);
+}
+
+.post-card-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.post-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.post-card-tags span {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(30, 64, 175, 0.08);
+  color: var(--dm-primary);
+}
+
+.post-card-link {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--dm-primary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: transform var(--dm-transition), color var(--dm-transition);
+}
+
+.post-card-link:hover {
+  color: var(--dm-primary-light);
+  transform: translateX(3px);
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.project-card {
+  position: relative;
+  background: var(--dm-surface);
+  border: 1px solid var(--dm-border);
+  border-radius: var(--dm-radius-lg);
+  padding: clamp(1.75rem, 4vw, 2.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  box-shadow: var(--dm-shadow-sm);
+  transition: transform var(--dm-transition), box-shadow var(--dm-transition), border-color var(--dm-transition);
+}
+
+body.dark .project-card {
+  background: var(--dm-surface-alt);
+}
+
+.project-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.18), rgba(59, 130, 246, 0.08));
+  opacity: 0;
+  transition: opacity var(--dm-transition);
+  z-index: 0;
+}
+
+.project-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--dm-shadow);
+  border-color: rgba(30, 64, 175, 0.35);
+}
+
+.project-card:hover::before {
+  opacity: 1;
+}
+
+.project-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.project-card h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--dm-text);
+}
+
+.project-card p {
+  color: var(--dm-text-muted);
+}
+
+.project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.project-tags span {
+  font-size: 0.75rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(30, 64, 175, 0.12);
+  color: var(--dm-primary);
+  font-weight: 600;
+}
+
+.project-link {
+  align-self: flex-start;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--dm-primary);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.project-link:hover {
+  color: var(--dm-primary-light);
+}
+
+.contact-panel {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--dm-radius-lg);
+  padding: clamp(2rem, 6vw, 3rem);
+  background: linear-gradient(135deg, var(--dm-primary) 0%, var(--dm-primary-light) 45%, #60a5fa 100%);
+  color: #fff;
+  box-shadow: var(--dm-shadow);
+}
+
+.contact-panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle at 25% 30%, rgba(255, 255, 255, 0.2) 0, transparent 55%),
+    radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.18) 0, transparent 55%);
+  opacity: 0.35;
+}
+
+.contact-panel-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.contact-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--dm-radius);
+  font-weight: 600;
+  text-decoration: none;
+  min-height: 48px;
+  transition: transform var(--dm-transition), box-shadow var(--dm-transition), background var(--dm-transition), color var(--dm-transition);
+}
+
+.contact-actions a.primary {
+  background: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  box-shadow: var(--dm-shadow-sm);
+}
+
+.contact-actions a.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--dm-shadow);
+}
+
+.contact-actions a.secondary {
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.contact-actions a.secondary:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.home .prose-block {
+  background: var(--dm-surface-alt);
+  border: 1px solid var(--dm-border);
+  border-radius: var(--dm-radius-lg);
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  box-shadow: var(--dm-shadow-sm);
+  color: var(--dm-text-muted);
+}
+
+.home .prose-block h2,
+.home .prose-block h3 {
+  color: var(--dm-text);
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 550ms var(--dm-transition), transform 650ms var(--dm-transition);
+}
+
+.fade-in.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.post-single {
+  background: var(--dm-surface);
+  border-radius: var(--dm-radius-lg);
+  border: 1px solid var(--dm-border);
+  box-shadow: var(--dm-shadow-sm);
+  padding: clamp(2rem, 4vw, 3rem);
+}
+
+body.dark .post-single {
+  background: var(--dm-surface-alt);
+}
+
+.post-title {
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
+  letter-spacing: -0.02em;
+}
+
+.post-description {
+  color: var(--dm-text-muted);
+  font-size: 1.05rem;
+}
+
+.post-content {
+  font-size: 1.05rem;
+  color: var(--dm-text);
+  line-height: 1.8;
+}
+
+.post-content p {
+  margin-bottom: 1.4rem;
+}
+
+.post-content h2,
+.post-content h3,
+.post-content h4 {
+  color: var(--dm-primary);
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.post-content pre,
+.post-content code {
+  font-family: var(--dm-font-mono);
+}
+
+.post-content pre {
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  padding: 1.25rem;
+  border-radius: 0.9rem;
+  overflow-x: auto;
+  box-shadow: var(--dm-shadow-sm);
+}
+
+.post-content blockquote {
+  border-left: 4px solid var(--dm-primary);
+  padding: 1rem 1.25rem;
+  background: rgba(30, 64, 175, 0.06);
+  border-radius: 0 0.75rem 0.75rem 0;
+  color: var(--dm-primary-dark);
+  font-style: italic;
+}
+
+.footer {
+  background: var(--dm-surface-alt);
+  border-top: 1px solid var(--dm-border);
+  padding: clamp(2.5rem, 5vw, 3.5rem) 0;
+}
+
+.footer .footer-menu,
+.footer .social-icons {
+  justify-content: center;
+}
+
+.footer hr {
+  display: none;
+}
+
+.footer .copyright {
+  color: var(--dm-text-muted);
+}
+
+@media (max-width: 900px) {
+  .nav {
+    padding-inline: clamp(1rem, 6vw, 1.5rem);
+  }
+
+  #menu {
+    gap: 1rem;
+  }
+
+  .logo-switches {
+    margin-left: auto;
+  }
+
+  .home-hero-grid {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-copy,
+  .hero-companies,
+  .hero-actions {
+    justify-content: center;
+    align-items: center;
+  }
+
+  .hero-subtitle {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (max-width: 720px) {
+  .nav {
+    flex-wrap: wrap;
+    row-gap: 1rem;
+  }
+
+  #menu {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .logo-switches {
+    order: 2;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  #theme-toggle {
+    width: 42px;
+    height: 42px;
+  }
+}
+
+@media (max-width: 640px) {
+  .home .section-wrapper {
+    width: min(var(--main-width), calc(100% - 2.25rem));
+  }
+
+  .hero-image-wrapper::before {
+    inset: -1rem;
+  }
+
+  .hero-image {
+    width: min(260px, 80vw);
+  }
+
+  .hero-actions a {
+    width: 100%;
+  }
+
+  .contact-actions a {
+    width: 100%;
+  }
+}
+
+@keyframes heroPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.15);
+    opacity: 0.6;
+  }
+}

--- a/blog/assets/images/dm-logo.svg
+++ b/blog/assets/images/dm-logo.svg
@@ -1,0 +1,12 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="14" fill="#1e40af" />
+  <defs>
+    <linearGradient id="dmGradient" x1="4" y1="4" x2="60" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1e40af" />
+      <stop offset="0.55" stop-color="#3b82f6" />
+      <stop offset="1" stop-color="#60a5fa" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#dmGradient)" />
+  <path d="M20.5 44V20h8.3c5.5 0 9.2 3.6 9.2 9.6 0 6.2-3.7 9.6-9.2 9.6h-4.2V44h-4.1Zm12.6 0 9-24h4.4l9 24h-4.4l-2-5.6h-9.6L37.5 44h-4.4Zm7.3-9.2h6.6l-3.3-9.4-3.3 9.4Z" fill="#fff" />
+</svg>

--- a/blog/content/_index.md
+++ b/blog/content/_index.md
@@ -1,13 +1,16 @@
 ---
 title: "Dominic Minischetti"
-description: "Developer, problem solver, and lifelong learner. Welcome to my sandbox."
+description: "Engineering notes on performance optimization, scalable architecture, and reliable delivery."
 ---
 
-# **Welcome to My Sandbox**  
+## Purpose of these notes
 
-A **sandbox** is a place to **experiment, build, and explore**—and that’s exactly what this site is. Here, I share my journey as a developer, my thoughts on tech, and the occasional life insight. Expect a mix of **coding, problem-solving, and everyday adventures.**  
+This space extends the work I do for product teams every day—refining PHP codebases, unlocking database performance, and building systems that can handle the next wave of traffic. Writing forces clarity, and these articles document the trade-offs, tooling, and practices that keep platforms dependable.
 
-*(Why "sandbox"? In programming, a sandbox is a space to test ideas safely. This site is my personal sandbox—where I tinker, learn, and have fun! My daughter even drew a sandbox just for me. ❤️)*  
+### What to expect
 
-{{< figure src="/blog/images/sandbox.png" alt="Dominic's Sandbox" width="100%" style="display: block; margin: 0 auto;" align="center" >}}  
-*My family's custom-built sandbox!*
+- Deep dives on query tuning, observability, and benchmarking efforts from real projects.
+- Architecture discussions that balance clean code with pragmatic delivery.
+- Team practices that keep engineers shipping quickly without burning out.
+
+If any post sparks an idea for your own platform, [reach out](mailto:dominic.minischetti@gmail.com)—I'd love to hear about it.

--- a/blog/hugo.yaml
+++ b/blog/hugo.yaml
@@ -1,4 +1,156 @@
-baseURL: http://minischetti.org/blog
+baseURL: https://minischetti.org/blog/
 languageCode: en-us
-title: My New Hugo Site
+title: Dominic Minischetti • Engineering Notes
 theme: PaperMod
+paginate: 10
+permalinks:
+  posts: /posts/:slug/
+outputs:
+  home:
+    - HTML
+    - RSS
+params:
+  env: production
+  title: Dominic Minischetti • Engineering Notes
+  author: Dominic Minischetti
+  description: Senior PHP backend engineer documenting performance wins, architecture decisions, and reliable delivery practices.
+  keywords:
+    - PHP performance
+    - Laravel
+    - MySQL optimization
+    - Backend engineering
+    - API architecture
+  defaultTheme: auto
+  disableThemeToggle: false
+  disableLangToggle: true
+  ShowReadingTime: true
+  ShowPostNavLinks: true
+  ShowBreadCrumbs: true
+  ShowCodeCopyButtons: true
+  DateFormat: 'Jan 2, 2006'
+  label:
+    text: Dominic Minischetti
+    icon: images/dm-logo.svg
+    iconHeight: 36
+  assets:
+    favicon: favicons/favicon.ico
+    favicon16x16: favicons/favicon-16x16.png
+    favicon32x32: favicons/favicon-32x32.png
+    apple_touch_icon: favicons/apple-touch-icon.png
+    androidChrome192x192: favicons/android-chrome-192x192.png
+    androidChrome512x512: favicons/android-chrome-512x512.png
+  socialIcons:
+    - name: linkedin
+      title: Connect on LinkedIn
+      url: https://linkedin.com/in/dminischetti/
+    - name: github
+      title: Explore GitHub
+      url: https://github.com/dminischetti
+    - name: email
+      title: Email Dominic
+      url: mailto:dominic.minischetti@gmail.com
+  hero:
+    badge: Open to new opportunities
+    title: Engineering notes on scalable PHP systems
+    subtitle: >-
+      Insights from architecting and optimizing PHP, MySQL, and API platforms for high-growth teams.
+    experience:
+      - BLOX Digital
+      - Appliances Connection
+      - Kingsleague
+    image: images/dominic_photo.png
+    imageAlt: Dominic Minischetti portrait
+    primaryCTA:
+      label: Schedule a Call
+      url: https://calendly.com/minischetti/meeting
+    secondaryCTA:
+      label: Browse Articles
+      url: /posts/
+  sections:
+    about:
+      title: Pragmatic backend engineering, documented
+      description: >-
+        I help teams modernize legacy platforms, squeeze more performance out of MySQL, and deliver reliable APIs.
+      body: |-
+        Each article distills the lessons I learn while building and optimizing production systems. Expect deep dives on performance tuning, clean architecture, resilient infrastructure, and the occasional story about shipping under pressure.
+    focus:
+      title: What you'll find here
+      description: Stories from production systems that keep revenue flowing and teams calm under pressure.
+      cards:
+        - title: Performance & Observability
+          description: Practical tactics for understanding system behavior, tightening feedback loops, and eliminating bottlenecks.
+          topics:
+            - Query optimization stories
+            - Observability playbooks
+            - Real-world benchmarks
+        - title: Scalable Architecture
+          description: Field notes on designing services that stay maintainable and fast as traffic grows.
+          topics:
+            - API design decisions
+            - Modular PHP patterns
+            - Deployment workflows
+        - title: Team Enablement
+          description: Processes and habits that help engineering teams move quickly without breaking things.
+          topics:
+            - Code review frameworks
+            - Documentation habits
+            - Tooling for focus
+    articles:
+      eyebrow: Latest writing
+      title: Fresh from the engineering desk
+      description: Notes on squeezing more performance from PHP and MySQL, designing resilient APIs, and supporting healthy engineering teams.
+      moreLabel: View all articles
+      moreURL: /posts/
+    projects:
+      eyebrow: Case studies
+      title: Featured case studies
+      description: Highlights from platforms I've led and optimized for growth-focused teams.
+      items:
+        - name: Warehouse Management System Rebuild
+          summary: Re-architected a warehouse platform around handheld workflows, real-time inventory accuracy, and measurable KPIs.
+          tags:
+            - PHP
+            - MySQL
+            - Bootstrap
+            - Process Automation
+          link:
+            label: Request a walkthrough
+            url: https://calendly.com/minischetti/meeting
+        - name: Unified REST API Platform
+          summary: Standardized authentication, documentation, and rate-limiting to align multiple partner integrations behind a single contract.
+          tags:
+            - REST
+            - JWT
+            - Swagger
+            - Monitoring
+          link:
+            label: Explore integration options
+            url: mailto:dominic.minischetti@gmail.com
+    contact:
+      title: Let's build something reliable
+      message: Tell me about the platform you're improving and I'll respond within one business day.
+      primaryCTA:
+        label: Book a call
+        url: https://calendly.com/minischetti/meeting
+      secondaryCTA:
+        label: Email Dominic
+        url: mailto:dominic.minischetti@gmail.com
+menu:
+  main:
+    - identifier: posts
+      name: Articles
+      url: /posts/
+      weight: 10
+    - identifier: projects
+      name: Projects
+      url: /#projects
+      weight: 20
+    - identifier: contact
+      name: Contact
+      url: https://calendly.com/minischetti/meeting
+      weight: 30
+      params:
+        external: true
+taxonomies:
+  tag: tags
+  category: categories

--- a/blog/layouts/index.html
+++ b/blog/layouts/index.html
@@ -1,0 +1,188 @@
+{{ define "main" }}
+  {{ $hero := site.Params.hero }}
+  <div class="home">
+    <section class="home-hero fade-in" id="top">
+      <div class="section-wrapper">
+        <div class="home-hero-grid">
+          <div class="hero-copy">
+            {{ with $hero.badge }}<span class="hero-badge">{{ . }}</span>{{ end }}
+            {{ with $hero.title }}<h1 class="hero-title">{{ . | markdownify }}</h1>{{ end }}
+            {{ with $hero.subtitle }}<p class="hero-subtitle">{{ . }}</p>{{ end }}
+            {{ with $hero.experience }}
+              <div class="hero-companies">
+                {{ range . }}<span>{{ . }}</span>{{ end }}
+              </div>
+            {{ end }}
+            <div class="hero-actions">
+              {{ with $hero.primaryCTA }}
+                {{ $url := .url }}
+                {{ $href := cond (or (strings.HasPrefix $url "http") (strings.HasPrefix $url "mailto:") (strings.HasPrefix $url "tel:") (strings.HasPrefix $url "#")) $url ($url | relURL) }}
+                <a class="primary" href="{{ $href }}">{{ .label }}</a>
+              {{ end }}
+              {{ with $hero.secondaryCTA }}
+                {{ $url := .url }}
+                {{ $href := cond (or (strings.HasPrefix $url "http") (strings.HasPrefix $url "mailto:") (strings.HasPrefix $url "tel:") (strings.HasPrefix $url "#")) $url ($url | relURL) }}
+                <a class="secondary" href="{{ $href }}">{{ .label }}</a>
+              {{ end }}
+            </div>
+          </div>
+          {{ with $hero.image }}
+            {{ $imageAlt := or $hero.imageAlt (printf "%s portrait" (site.Params.author | default site.Title)) }}
+            <div class="hero-image-wrapper">
+              <img class="hero-image" src="{{ . | relURL }}" alt="{{ $imageAlt }}" loading="eager" width="420" height="520" />
+            </div>
+          {{ end }}
+        </div>
+      </div>
+    </section>
+
+    {{ with site.Params.sections.about }}
+      <section class="home-section fade-in" id="about">
+        <div class="section-wrapper">
+          <div class="section-header">
+            <span class="section-eyebrow">About</span>
+            <h2 class="section-title">{{ .title }}</h2>
+            {{ with .description }}<p class="section-description">{{ . }}</p>{{ end }}
+          </div>
+          {{ with .body }}
+            <div class="about-body">{{ . | markdownify }}</div>
+          {{ end }}
+        </div>
+      </section>
+    {{ end }}
+
+    {{ with site.Params.sections.focus }}
+      <section class="home-section fade-in" id="focus">
+        <div class="section-wrapper">
+          <div class="section-header">
+            <span class="section-eyebrow">Focus</span>
+            <h2 class="section-title">{{ .title }}</h2>
+            {{ with .description }}<p class="section-description">{{ . }}</p>{{ end }}
+          </div>
+          {{ with .cards }}
+            <div class="focus-grid">
+              {{ range . }}
+                <article class="focus-card fade-in">
+                  <h3>{{ .title }}</h3>
+                  {{ with .description }}<p>{{ . }}</p>{{ end }}
+                  {{ with .topics }}
+                    <ul>
+                      {{ range . }}<li>{{ . }}</li>{{ end }}
+                    </ul>
+                  {{ end }}
+                </article>
+              {{ end }}
+            </div>
+          {{ end }}
+        </div>
+      </section>
+    {{ end }}
+
+    {{ $articles := site.Params.sections.articles }}
+    {{ $posts := first 6 (sort (where site.RegularPages "Type" "posts") "Date" "desc") }}
+    {{ if gt (len $posts) 0 }}
+      <section class="home-section fade-in" id="articles">
+        <div class="section-wrapper">
+          <div class="section-header">
+            <span class="section-eyebrow">{{ $articles.eyebrow | default "Latest writing" }}</span>
+            <h2 class="section-title">{{ $articles.title | default "Recent Articles" }}</h2>
+            {{ with $articles.description }}<p class="section-description">{{ . }}</p>{{ end }}
+          </div>
+          <div class="post-grid">
+            {{ range $posts }}
+              <article class="post-card fade-in">
+                <a class="post-card-title" href="{{ .RelPermalink }}">{{ .Title }}</a>
+                <div class="post-card-meta">
+                  <span>{{ .Date | time.Format "Jan 2, 2006" }}</span>
+                  {{ with .ReadingTime }}<span>{{ . }} min read</span>{{ end }}
+                </div>
+                {{ $summary := .Params.description | default (.Summary | default "") }}
+                {{ if $summary }}<p>{{ $summary | plainify | truncate 180 }}</p>{{ end }}
+                {{ with .Params.tags }}
+                  <div class="post-card-tags">
+                    {{ range first 4 . }}<span>{{ . }}</span>{{ end }}
+                  </div>
+                {{ end }}
+                <a class="post-card-link" href="{{ .RelPermalink }}">Read the article →</a>
+              </article>
+            {{ end }}
+          </div>
+          {{ with $articles.moreLabel }}
+            {{ $url := $articles.moreURL | default "/posts/" }}
+            {{ $href := cond (or (strings.HasPrefix $url "http") (strings.HasPrefix $url "mailto:") (strings.HasPrefix $url "tel:") (strings.HasPrefix $url "#")) $url ($url | relURL) }}
+            <div class="hero-actions" style="margin-top: clamp(2rem, 5vw, 3rem);">
+              <a class="secondary" href="{{ $href }}">{{ . }}</a>
+            </div>
+          {{ end }}
+        </div>
+      </section>
+    {{ end }}
+
+    {{ with site.Params.sections.projects }}
+      <section class="home-section fade-in" id="projects">
+        <div class="section-wrapper">
+          <div class="section-header">
+            <span class="section-eyebrow">{{ .eyebrow | default "Case Studies" }}</span>
+            <h2 class="section-title">{{ .title }}</h2>
+            {{ with .description }}<p class="section-description">{{ . }}</p>{{ end }}
+          </div>
+          {{ with .items }}
+            <div class="project-grid">
+              {{ range . }}
+                <article class="project-card fade-in">
+                  <h3>{{ .name }}</h3>
+                  {{ with .summary }}<p>{{ . }}</p>{{ end }}
+                  {{ with .tags }}
+                    <div class="project-tags">
+                      {{ range . }}<span>{{ . }}</span>{{ end }}
+                    </div>
+                  {{ end }}
+                  {{ with .link }}
+                    {{ $url := .url }}
+                    {{ $href := cond (or (strings.HasPrefix $url "http") (strings.HasPrefix $url "mailto:") (strings.HasPrefix $url "tel:") (strings.HasPrefix $url "#")) $url ($url | relURL) }}
+                    <a class="project-link" href="{{ $href }}">{{ .label }} →</a>
+                  {{ end }}
+                </article>
+              {{ end }}
+            </div>
+          {{ end }}
+        </div>
+      </section>
+    {{ end }}
+
+    {{ with site.Params.sections.contact }}
+      <section class="home-section fade-in" id="contact">
+        <div class="section-wrapper">
+          <div class="contact-panel">
+            <div class="contact-panel-content">
+              <div>
+                <h2>{{ .title }}</h2>
+                {{ with .message }}<p>{{ . }}</p>{{ end }}
+              </div>
+              <div class="contact-actions">
+                {{ with .primaryCTA }}
+                  {{ $url := .url }}
+                  {{ $href := cond (or (strings.HasPrefix $url "http") (strings.HasPrefix $url "mailto:") (strings.HasPrefix $url "tel:") (strings.HasPrefix $url "#")) $url ($url | relURL) }}
+                  <a class="primary" href="{{ $href }}">{{ .label }}</a>
+                {{ end }}
+                {{ with .secondaryCTA }}
+                  {{ $url := .url }}
+                  {{ $href := cond (or (strings.HasPrefix $url "http") (strings.HasPrefix $url "mailto:") (strings.HasPrefix $url "tel:") (strings.HasPrefix $url "#")) $url ($url | relURL) }}
+                  <a class="secondary" href="{{ $href }}">{{ .label }}</a>
+                {{ end }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    {{ end }}
+
+    {{ with .Content }}
+      <section class="home-section fade-in">
+        <div class="section-wrapper">
+          <div class="prose-block">{{ . }}</div>
+        </div>
+      </section>
+    {{ end }}
+  </div>
+{{ end }}

--- a/blog/layouts/partials/extend_footer.html
+++ b/blog/layouts/partials/extend_footer.html
@@ -1,0 +1,57 @@
+<script>
+(function () {
+  const header = document.querySelector('.header');
+  if (!header) return;
+  const setScrolled = () => {
+    const isScrolled = window.scrollY > 24;
+    header.classList.toggle('is-scrolled', isScrolled);
+  };
+  setScrolled();
+  window.addEventListener('scroll', () => requestAnimationFrame(setScrolled), { passive: true });
+})();
+
+(function () {
+  const elements = document.querySelectorAll('.fade-in');
+  if (!('IntersectionObserver' in window) || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    elements.forEach((el) => el.classList.add('is-visible'));
+    return;
+  }
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          obs.unobserve(entry.target);
+        }
+      });
+    },
+    { rootMargin: '0px 0px -15%', threshold: 0.15 }
+  );
+  elements.forEach((el) => observer.observe(el));
+})();
+
+(function () {
+  const header = document.querySelector('.header');
+  const links = document.querySelectorAll('a[href^="#"]');
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  links.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      const targetId = link.getAttribute('href');
+      if (!targetId || targetId.length < 2) return;
+      const target = document.querySelector(targetId);
+      if (!target) return;
+      event.preventDefault();
+      const headerOffset = header ? header.offsetHeight + 12 : 0;
+      const top = target.getBoundingClientRect().top + window.scrollY - headerOffset;
+      if (prefersReduced) {
+        window.scrollTo(0, top);
+      } else {
+        window.scrollTo({ top, behavior: 'smooth' });
+      }
+      if (history.pushState) {
+        history.pushState(null, '', targetId);
+      }
+    });
+  });
+})();
+</script>

--- a/blog/layouts/partials/extend_head.html
+++ b/blog/layouts/partials/extend_head.html
@@ -1,0 +1,27 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<meta name="theme-color" content="#1e40af" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">
+{{ with site.Params.keywords }}<meta name="keywords" content="{{ delimit . ", " }}">{{ end }}
+{{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
+{{ with site.Params.hero.image }}<link rel="preload" as="image" href="{{ . | relURL }}" imagesrcset="{{ . | relURL }}" imagesizes="(min-width: 768px) 420px, 70vw">{{ end }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "{{ site.Params.author | default site.Title }}",
+  "url": "https://minischetti.org",
+  "image": "{{ (site.Params.hero.image | default "images/dominic_photo.png") | absURL }}",
+  "jobTitle": "Senior PHP Backend Engineer",
+  "sameAs": [
+    "https://linkedin.com/in/dminischetti/",
+    "https://github.com/dminischetti"
+  ],
+  "worksFor": {
+    "@type": "Organization",
+    "name": "BLOX Digital"
+  },
+  "knowsAbout": ["PHP", "Laravel", "MySQL", "Performance Optimization", "API Architecture"],
+  "description": "{{ site.Params.description }}"
+}
+</script>


### PR DESCRIPTION
## Summary
- configure PaperMod with branded metadata, menus, and homepage section copy tailored to minischetti.org
- implement a custom home layout with hero, focus areas, latest articles, case studies, and contact CTA driven by site params
- deliver a full design refresh with extended CSS, branded logo asset, structured data, and smooth fade-in/scroll behaviours

## Testing
- not run (Hugo CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e322006e2c832eb7fa3faadfd7cfb1