### PR TITLE
Update Hugo pagination config

### DIFF
--- a/blog/hugo.yaml
+++ b/blog/hugo.yaml
@@ -2,7 +2,8 @@ baseURL: https://minischetti.org/blog/
 languageCode: en-us
 title: Dominic Minischetti • Engineering Notes
 theme: PaperMod
-paginate: 10
+pagination:
+  pagerSize: 10
 permalinks:
   posts: /posts/:slug/
 outputs:


### PR DESCRIPTION
## Summary
- replace the deprecated `paginate` configuration with `pagination.pagerSize` in the Hugo site config

## Testing
- ⚠️ `hugo --minify --baseURL "https://minischetti.org/blog/"` *(fails in CI image: `hugo` command not found locally)*

------
https://chatgpt.com/codex/tasks/task_e_68e41c3965c0832eb1b1fc0b934665e0