### PR TITLE
Restore PaperMod theme toggle and align header styling

### DIFF
--- a/blog/assets/css/extended/header.css
+++ b/blog/assets/css/extended/header.css
@@ -1,0 +1,96 @@
+.header {
+  background: var(--theme);
+  color: var(--primary);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 0;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.logo-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  background: var(--entry);
+  color: var(--primary);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.back-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.back-link:hover,
+.back-link:focus {
+  text-decoration: underline;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--primary);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  background: var(--entry);
+}
+
+.theme-toggle svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.header-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .header-inner {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .header-controls {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}

--- a/blog/hugo.yaml
+++ b/blog/hugo.yaml
@@ -14,4 +14,6 @@ params:
   label:
     text: "← Back to Home"
     url: "/"
+  defaultTheme: auto
+  disableThemeToggle: false
 

--- a/blog/layouts/partials/header.html
+++ b/blog/layouts/partials/header.html
@@ -1,108 +1,73 @@
 {{- $defaultTheme := site.Params.defaultTheme | default "auto" -}}
 {{- $disableToggle := site.Params.disableThemeToggle | default false -}}
 
-<header class="header" role="banner">
-  <div class="header-inner">
-    <div class="header-content">
-      <!-- Logo -->
-      <a href="/" class="logo" aria-label="Torna alla Homepage">
-        <span class="logo-icon">DM</span>
-        <span class="logo-text">Dominic Minischetti</span>
-      </a>
+{{- if (not $disableToggle) }}
+  {{- if eq $defaultTheme "light" }}
+<script>
+  if (localStorage.getItem("pref-theme") === "dark") {
+    document.body.classList.add("dark");
+  }
+</script>
+  {{- else if eq $defaultTheme "dark" }}
+<script>
+  if (localStorage.getItem("pref-theme") === "light") {
+    document.body.classList.remove("dark");
+  }
+</script>
+  {{- else }}
+<script>
+  if (localStorage.getItem("pref-theme") === "dark") {
+    document.body.classList.add("dark");
+  } else if (localStorage.getItem("pref-theme") === "light") {
+    document.body.classList.remove("dark");
+  } else if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    document.body.classList.add("dark");
+  }
+</script>
+  {{- end }}
+{{- else if and (ne $defaultTheme "light") (ne $defaultTheme "dark") }}
+<script>
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    document.body.classList.add("dark");
+  }
+</script>
+{{- end }}
 
-      <!-- Back to Blog (solo nelle pagine articolo) -->
-      {{ if .IsPage }}
+<header class="header" role="banner">
+  <div class="container header-inner">
+    <a href="/" class="logo" aria-label="Torna alla Homepage">
+      <span class="logo-icon">DM</span>
+      <span class="logo-text">Dominic Minischetti</span>
+    </a>
+
+    <div class="header-controls">
+      {{- if .IsPage }}
       <a href="/blog" class="back-link" aria-label="Torna al Blog">
-        <svg class="back-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M19 12H5M12 19l-7-7 7-7"/>
+        <svg class="back-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5M12 19l-7-7 7-7" />
         </svg>
         <span>Blog</span>
       </a>
-      {{ end }}
+      {{- end }}
+
+      {{- if not $disableToggle }}
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme" type="button">
+        <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+        <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5"></circle>
+          <line x1="12" y1="1" x2="12" y2="3"></line>
+          <line x1="12" y1="21" x2="12" y2="23"></line>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+          <line x1="1" y1="12" x2="3" y2="12"></line>
+          <line x1="21" y1="12" x2="23" y2="12"></line>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+      </button>
+      {{- end }}
     </div>
   </div>
-
-  {{ if not $disableToggle }}
-  <!-- Theme Toggle Button -->
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme" type="button">
-    <svg class="sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="5"></circle>
-      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"></path>
-    </svg>
-    <svg class="moon-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-    </svg>
-  </button>
-  {{ end }}
 </header>
-
-{{ if not $disableToggle }}
-<script>
-(function () {
-  const storageKey = "pref-theme";
-  const defaultTheme = "{{ $defaultTheme }}";
-  const button = document.getElementById("theme-toggle");
-  const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
-  const root = document.body || document.documentElement;
-  const themeMeta = document.querySelector('meta[name="theme-color"]');
-
-  if (!root || !button) {
-    return;
-  }
-
-  const updateMeta = (theme) => {
-    if (!themeMeta) return;
-    themeMeta.setAttribute("content", theme === "dark" ? "#0f172a" : "#ffffff");
-  };
-
-  const applyTheme = (theme) => {
-    const isDark = theme === "dark";
-    root.classList.toggle("dark", isDark);
-    root.dataset.theme = isDark ? "dark" : "light";
-    button.setAttribute("aria-pressed", String(isDark));
-    updateMeta(isDark ? "dark" : "light");
-    return isDark ? "dark" : "light";
-  };
-
-  const storedTheme = localStorage.getItem(storageKey);
-
-  const initialTheme = (() => {
-    if (storedTheme === "dark" || storedTheme === "light") {
-      return storedTheme;
-    }
-    switch (defaultTheme) {
-      case "dark":
-        return "dark";
-      case "light":
-        return "light";
-      default:
-        return prefersDark && prefersDark.matches ? "dark" : "light";
-    }
-  })();
-
-  applyTheme(initialTheme);
-
-  button.addEventListener("click", () => {
-    const nextTheme = root.classList.contains("dark") ? "light" : "dark";
-    applyTheme(nextTheme);
-    localStorage.setItem(storageKey, nextTheme);
-    if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
-      navigator.vibrate(10);
-    }
-  });
-
-  if (!storedTheme && defaultTheme === "auto" && prefersDark) {
-    const listener = (event) => {
-      const newTheme = event.matches ? "dark" : "light";
-      applyTheme(newTheme);
-    };
-    if (typeof prefersDark.addEventListener === "function") {
-      prefersDark.addEventListener("change", listener);
-    } else if (typeof prefersDark.addListener === "function") {
-      prefersDark.addListener(listener);
-    }
-  }
-})();
-</script>
-{{ end }}
-


### PR DESCRIPTION
## Summary
- restore PaperMod’s inline theme bootstrap logic in the custom header and rely on the built-in toggle markup
- expose the default theme and toggle controls in the Hugo config
- add theme-aware header styles that respect PaperMod color variables and provide layout spacing for the toggle and back link

## Testing
- ⚠️ `hugo --source blog` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4706d32f8832eb43b91ff690aa916